### PR TITLE
Refactor: Enhance Todo Model and Implement Update Functionality

### DIFF
--- a/lib/data/repositories/todo_repository.dart
+++ b/lib/data/repositories/todo_repository.dart
@@ -13,4 +13,6 @@ abstract class TodoRepository {
   Future<Result<void>> delete(Todo todo);
 
   Future<Result<Todo>> getById(String id);
+
+  Future<Result<Todo>> update(Todo todo);
 }

--- a/lib/data/repositories/todo_repository.dart
+++ b/lib/data/repositories/todo_repository.dart
@@ -4,7 +4,11 @@ import 'package:mvvm_template_with_flutter/domain/models/todo.dart';
 abstract class TodoRepository {
   Future<Result<List<Todo>>> get();
 
-  Future<Result<Todo>> add(String name);
+  Future<Result<Todo>> add({
+    required String name,
+    required String description,
+    required bool done,
+  });
 
   Future<Result<void>> delete(Todo todo);
 

--- a/lib/data/repositories/todo_repository_dev.dart
+++ b/lib/data/repositories/todo_repository_dev.dart
@@ -43,4 +43,13 @@ class TodoRepositoryDev extends TodoRepository {
   Future<Result<Todo>> getById(String id) async {
     return Result.ok(_todos.where((e) => e.id == id).first);
   }
+
+  @override
+  Future<Result<Todo>> update(Todo todo) async {
+    final todoIndex = _todos.indexWhere((e) => e.id == todo.id);
+
+    _todos[todoIndex] = todo;
+
+    return Result.ok(todo);
+  }
 }

--- a/lib/data/repositories/todo_repository_dev.dart
+++ b/lib/data/repositories/todo_repository_dev.dart
@@ -6,10 +6,19 @@ class TodoRepositoryDev extends TodoRepository {
   final List<Todo> _todos = [];
 
   @override
-  Future<Result<Todo>> add(String name) async {
+  Future<Result<Todo>> add({
+    required String name,
+    required String description,
+    required bool done,
+  }) async {
     final lastIndex = _todos.length;
 
-    final createdTodo = Todo(id: '${lastIndex + 1}', name: name);
+    final createdTodo = Todo(
+      id: '${lastIndex + 1}',
+      name: name,
+      description: description,
+      done: done,
+    );
 
     _todos.add(createdTodo);
 

--- a/lib/data/repositories/todo_repository_remote.dart
+++ b/lib/data/repositories/todo_repository_remote.dart
@@ -11,7 +11,11 @@ class TodoRepositoryRemote implements TodoRepository {
   final ApiClient _apiClient;
 
   @override
-  Future<Result<Todo>> add(String name) async {
+  Future<Result<Todo>> add({
+    required String name,
+    required String description,
+    required bool done,
+  }) async {
     try {
       final result = await _apiClient.postTodo(CreateTodoApiModel(name: name));
 

--- a/lib/data/repositories/todo_repository_remote.dart
+++ b/lib/data/repositories/todo_repository_remote.dart
@@ -17,7 +17,9 @@ class TodoRepositoryRemote implements TodoRepository {
     required bool done,
   }) async {
     try {
-      final result = await _apiClient.postTodo(CreateTodoApiModel(name: name));
+      final result = await _apiClient.postTodo(
+        CreateTodoApiModel(name: name, description: description, done: done),
+      );
 
       switch (result) {
         case Ok<Todo>():
@@ -66,6 +68,29 @@ class TodoRepositoryRemote implements TodoRepository {
   Future<Result<Todo>> getById(String id) async {
     try {
       final result = await _apiClient.getById(id);
+      switch (result) {
+        case Ok<Todo>():
+          return Result.ok(result.value);
+        default:
+          return result;
+      }
+    } on Exception catch (error) {
+      return Result.error(error);
+    }
+  }
+
+  @override
+  Future<Result<Todo>> update(Todo todo) async {
+    try {
+      final result = await _apiClient.updateTodo(
+        UpdateTodoApiModel(
+          id: todo.id!,
+          name: todo.name,
+          description: todo.description,
+          done: todo.done,
+        ),
+      );
+
       switch (result) {
         case Ok<Todo>():
           return Result.ok(result.value);

--- a/lib/data/services/api/api_client.dart
+++ b/lib/data/services/api/api_client.dart
@@ -73,7 +73,7 @@ class ApiClient {
 
       final response = await request.close();
 
-      if (response.statusCode == 201) {
+      if (response.statusCode == 200) {
         final stringData = await response.transform(utf8.decoder).join();
         final json = jsonDecode(stringData) as Map<String, dynamic>;
         final createdTodo = Todo.fromJson(json);

--- a/lib/data/services/api/models/todo/todo_api_model.dart
+++ b/lib/data/services/api/models/todo/todo_api_model.dart
@@ -5,12 +5,17 @@ part 'todo_api_model.freezed.dart';
 
 @freezed
 sealed class TodoApiModel with _$TodoApiModel {
-  const factory TodoApiModel.create({required String name}) =
-      CreateTodoApiModel;
-      
+  const factory TodoApiModel.create({
+    required String name,
+    required String description,
+    required bool done,
+  }) = CreateTodoApiModel;
+
   const factory TodoApiModel.update({
-    required String id, 
-    required String name
+    required String id,
+    required String name,
+    required String description,
+    required bool done,
   }) = UpdateTodoApiModel;
 
   factory TodoApiModel.fromJson(Map<String, Object?> json) =>

--- a/lib/data/services/api/models/todo/todo_api_model.freezed.dart
+++ b/lib/data/services/api/models/todo/todo_api_model.freezed.dart
@@ -38,7 +38,7 @@ TodoApiModel _$TodoApiModelFromJson(
 /// @nodoc
 mixin _$TodoApiModel {
 
- String get name;
+ String get name; String get description; bool get done;
 /// Create a copy of TodoApiModel
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -51,16 +51,16 @@ $TodoApiModelCopyWith<TodoApiModel> get copyWith => _$TodoApiModelCopyWithImpl<T
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is TodoApiModel&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TodoApiModel&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.done, done) || other.done == done));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name);
+int get hashCode => Object.hash(runtimeType,name,description,done);
 
 @override
 String toString() {
-  return 'TodoApiModel(name: $name)';
+  return 'TodoApiModel(name: $name, description: $description, done: $done)';
 }
 
 
@@ -71,7 +71,7 @@ abstract mixin class $TodoApiModelCopyWith<$Res>  {
   factory $TodoApiModelCopyWith(TodoApiModel value, $Res Function(TodoApiModel) _then) = _$TodoApiModelCopyWithImpl;
 @useResult
 $Res call({
- String name
+ String name, String description, bool done
 });
 
 
@@ -88,10 +88,12 @@ class _$TodoApiModelCopyWithImpl<$Res>
 
 /// Create a copy of TodoApiModel
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? description = null,Object? done = null,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,done: null == done ? _self.done : done // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -176,11 +178,11 @@ return update(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String name)?  create,TResult Function( String id,  String name)?  update,required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function( String name,  String description,  bool done)?  create,TResult Function( String id,  String name,  String description,  bool done)?  update,required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case CreateTodoApiModel() when create != null:
-return create(_that.name);case UpdateTodoApiModel() when update != null:
-return update(_that.id,_that.name);case _:
+return create(_that.name,_that.description,_that.done);case UpdateTodoApiModel() when update != null:
+return update(_that.id,_that.name,_that.description,_that.done);case _:
   return orElse();
 
 }
@@ -198,11 +200,11 @@ return update(_that.id,_that.name);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String name)  create,required TResult Function( String id,  String name)  update,}) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function( String name,  String description,  bool done)  create,required TResult Function( String id,  String name,  String description,  bool done)  update,}) {final _that = this;
 switch (_that) {
 case CreateTodoApiModel():
-return create(_that.name);case UpdateTodoApiModel():
-return update(_that.id,_that.name);}
+return create(_that.name,_that.description,_that.done);case UpdateTodoApiModel():
+return update(_that.id,_that.name,_that.description,_that.done);}
 }
 /// A variant of `when` that fallback to returning `null`
 ///
@@ -216,11 +218,11 @@ return update(_that.id,_that.name);}
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String name)?  create,TResult? Function( String id,  String name)?  update,}) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function( String name,  String description,  bool done)?  create,TResult? Function( String id,  String name,  String description,  bool done)?  update,}) {final _that = this;
 switch (_that) {
 case CreateTodoApiModel() when create != null:
-return create(_that.name);case UpdateTodoApiModel() when update != null:
-return update(_that.id,_that.name);case _:
+return create(_that.name,_that.description,_that.done);case UpdateTodoApiModel() when update != null:
+return update(_that.id,_that.name,_that.description,_that.done);case _:
   return null;
 
 }
@@ -232,10 +234,12 @@ return update(_that.id,_that.name);case _:
 @JsonSerializable()
 
 class CreateTodoApiModel implements TodoApiModel {
-  const CreateTodoApiModel({required this.name, final  String? $type}): $type = $type ?? 'create';
+  const CreateTodoApiModel({required this.name, required this.description, required this.done, final  String? $type}): $type = $type ?? 'create';
   factory CreateTodoApiModel.fromJson(Map<String, dynamic> json) => _$CreateTodoApiModelFromJson(json);
 
 @override final  String name;
+@override final  String description;
+@override final  bool done;
 
 @JsonKey(name: 'runtimeType')
 final String $type;
@@ -254,16 +258,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateTodoApiModel&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is CreateTodoApiModel&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.done, done) || other.done == done));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name);
+int get hashCode => Object.hash(runtimeType,name,description,done);
 
 @override
 String toString() {
-  return 'TodoApiModel.create(name: $name)';
+  return 'TodoApiModel.create(name: $name, description: $description, done: $done)';
 }
 
 
@@ -274,7 +278,7 @@ abstract mixin class $CreateTodoApiModelCopyWith<$Res> implements $TodoApiModelC
   factory $CreateTodoApiModelCopyWith(CreateTodoApiModel value, $Res Function(CreateTodoApiModel) _then) = _$CreateTodoApiModelCopyWithImpl;
 @override @useResult
 $Res call({
- String name
+ String name, String description, bool done
 });
 
 
@@ -291,10 +295,12 @@ class _$CreateTodoApiModelCopyWithImpl<$Res>
 
 /// Create a copy of TodoApiModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? description = null,Object? done = null,}) {
   return _then(CreateTodoApiModel(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,done: null == done ? _self.done : done // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 
@@ -305,11 +311,13 @@ as String,
 @JsonSerializable()
 
 class UpdateTodoApiModel implements TodoApiModel {
-  const UpdateTodoApiModel({required this.id, required this.name, final  String? $type}): $type = $type ?? 'update';
+  const UpdateTodoApiModel({required this.id, required this.name, required this.description, required this.done, final  String? $type}): $type = $type ?? 'update';
   factory UpdateTodoApiModel.fromJson(Map<String, dynamic> json) => _$UpdateTodoApiModelFromJson(json);
 
  final  String id;
 @override final  String name;
+@override final  String description;
+@override final  bool done;
 
 @JsonKey(name: 'runtimeType')
 final String $type;
@@ -328,16 +336,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is UpdateTodoApiModel&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is UpdateTodoApiModel&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.description, description) || other.description == description)&&(identical(other.done, done) || other.done == done));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,name);
+int get hashCode => Object.hash(runtimeType,id,name,description,done);
 
 @override
 String toString() {
-  return 'TodoApiModel.update(id: $id, name: $name)';
+  return 'TodoApiModel.update(id: $id, name: $name, description: $description, done: $done)';
 }
 
 
@@ -348,7 +356,7 @@ abstract mixin class $UpdateTodoApiModelCopyWith<$Res> implements $TodoApiModelC
   factory $UpdateTodoApiModelCopyWith(UpdateTodoApiModel value, $Res Function(UpdateTodoApiModel) _then) = _$UpdateTodoApiModelCopyWithImpl;
 @override @useResult
 $Res call({
- String id, String name
+ String id, String name, String description, bool done
 });
 
 
@@ -365,11 +373,13 @@ class _$UpdateTodoApiModelCopyWithImpl<$Res>
 
 /// Create a copy of TodoApiModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? description = null,Object? done = null,}) {
   return _then(UpdateTodoApiModel(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
-as String,
+as String,description: null == description ? _self.description : description // ignore: cast_nullable_to_non_nullable
+as String,done: null == done ? _self.done : done // ignore: cast_nullable_to_non_nullable
+as bool,
   ));
 }
 

--- a/lib/data/services/api/models/todo/todo_api_model.g.dart
+++ b/lib/data/services/api/models/todo/todo_api_model.g.dart
@@ -9,16 +9,25 @@ part of 'todo_api_model.dart';
 CreateTodoApiModel _$CreateTodoApiModelFromJson(Map<String, dynamic> json) =>
     CreateTodoApiModel(
       name: json['name'] as String,
+      description: json['description'] as String,
+      done: json['done'] as bool,
       $type: json['runtimeType'] as String?,
     );
 
 Map<String, dynamic> _$CreateTodoApiModelToJson(CreateTodoApiModel instance) =>
-    <String, dynamic>{'name': instance.name, 'runtimeType': instance.$type};
+    <String, dynamic>{
+      'name': instance.name,
+      'description': instance.description,
+      'done': instance.done,
+      'runtimeType': instance.$type,
+    };
 
 UpdateTodoApiModel _$UpdateTodoApiModelFromJson(Map<String, dynamic> json) =>
     UpdateTodoApiModel(
       id: json['id'] as String,
       name: json['name'] as String,
+      description: json['description'] as String,
+      done: json['done'] as bool,
       $type: json['runtimeType'] as String?,
     );
 
@@ -26,5 +35,7 @@ Map<String, dynamic> _$UpdateTodoApiModelToJson(UpdateTodoApiModel instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
+      'description': instance.description,
+      'done': instance.done,
       'runtimeType': instance.$type,
     };

--- a/lib/domain/models/todo.dart
+++ b/lib/domain/models/todo.dart
@@ -16,7 +16,7 @@ class Todo {
       id: json["id"],
       name: json["name"],
       description: json["description"],
-      done: json["don"],
+      done: json["done"],
     );
   }
 
@@ -27,9 +27,9 @@ class Todo {
   Todo copyWith({String? id, String? name, String? description, bool? done}) {
     return Todo(
       id: id ?? this.id,
-      name: this.name,
-      description: this.description,
-      done: this.done,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      done: done ?? this.done,
     );
   }
 }

--- a/lib/domain/models/todo.dart
+++ b/lib/domain/models/todo.dart
@@ -1,33 +1,35 @@
 class Todo {
   final String? id;
   final String name;
+  final String description;
+  final bool done;
 
-  Todo({this.id, required this.name});
+  Todo({
+    this.id,
+    required this.name,
+    required this.description,
+    required this.done,
+  });
 
   factory Todo.fromJson(Map<String, dynamic> json) {
-    return Todo(id: json["id"], name: json["name"]);
+    return Todo(
+      id: json["id"],
+      name: json["name"],
+      description: json["description"],
+      done: json["don"],
+    );
   }
 
   Map<String, dynamic> toJson() {
-    return {
-      'id': id,
-      'name': name,
-      // 'description': description,
-      // 'done': done,
-    };
+    return {'id': id, 'name': name, 'description': description, 'done': done};
   }
 
-  Todo copyWith({
-    String? id,
-    String? name,
-    String? description,
-    bool? done,
-  }) {
+  Todo copyWith({String? id, String? name, String? description, bool? done}) {
     return Todo(
       id: id ?? this.id,
-      name: name ?? this.name,
-      // description: description ?? this.description,
-      // done: done ?? this.done,
+      name: this.name,
+      description: this.description,
+      done: this.done,
     );
   }
 }

--- a/lib/ui/todo/viewmodels/todo_viewmodel.dart
+++ b/lib/ui/todo/viewmodels/todo_viewmodel.dart
@@ -8,15 +8,15 @@ class TodoViewmodel extends ChangeNotifier {
   TodoViewmodel({required TodoRepository todoRepository})
     : _todoRepository = todoRepository {
     load = Command0(_load)..execute();
-    addTodo = Command1<Todo, String>(_addTodo);
-    deleteTodo = Command1<void, Todo>(_deleteTodo);
+    addTodo = Command1(_addTodo);
+    deleteTodo = Command1(_deleteTodo);
   }
 
   final TodoRepository _todoRepository;
 
   late Command0 load;
-  late Command1 addTodo;
-  late Command1 deleteTodo;
+  late Command1<Todo, (String, String, bool)> addTodo;
+  late Command1<void, Todo> deleteTodo;
 
   List<Todo> _todos = [];
 
@@ -38,8 +38,10 @@ class TodoViewmodel extends ChangeNotifier {
     return result;
   }
 
-  Future<Result<Todo>> _addTodo(String name) async {
-    final result = await _todoRepository.add(name);
+  Future<Result<Todo>> _addTodo((String, String, bool) todo) async {
+    final (name, description, done) = todo;
+
+    final result = await _todoRepository.add(name: name, description: description, done: done);
 
     switch (result) {
       case Ok<Todo>():

--- a/lib/ui/todo/widgets/add_todo_form.dart
+++ b/lib/ui/todo/widgets/add_todo_form.dart
@@ -84,7 +84,11 @@ class _AddTodoFormState extends State<AddTodoForm> {
               ElevatedButton(
                 onPressed: () {
                   if (formKey.currentState?.validate() == true) {
-                    widget.todoViewmodel.addTodo.execute(nameController.text);
+                    widget.todoViewmodel.addTodo.execute((
+                      nameController.text,
+                      "",
+                      false,
+                    ));
                   }
                 },
                 child: Text('Salvar'),


### PR DESCRIPTION
## Overview:

This pull request closes https://github.com/do5-5anto5/mvvm_flutter/issues/20 . It refactors the Todo feature to comprehensively support update operations. Changes span from the data model and repository layers to API client interactions, ensuring that Todo items can be modified with their `description` and `done` status. This addresses the need to evolve our Todo management capabilities beyond just creation and retrieval.

**Key Changes & Refinements:**

*   **Model Enhancements:**
    *   The core `Todo` model has been updated to include `description` and `done` attributes. Constructors and relevant data handling logic across repositories, ViewModels, and UI forms (`add_todo_form`) have been adjusted accordingly (`refactor: Add attributes 'description' and 'done' to Todo model and it's constructors...`).
    *   The `TodoApiModel` (likely used for network communication) has been updated with the same `description` and `done` attributes, and the `freezed` generated files have been rebuilt to reflect these changes (`refactor: Add the same attributes to TodoApiModel - 'description' and 'done' - also rebuild freezed generated files`).
    *   Fixed `toJson` and `fromJson` methods in the `Todo` model to ensure correct serialization and deserialization with the new attributes (`fix Todo.toJson and Todo.fromJson`).
*   **Repository Layer Update Capability:**
    *   An `updateTodo` function has been added to the abstract `TodoRepository` class, defining the contract for update operations (`refactor: set an updateTodo function to abstract class TodoRepository`).
    *   This `updateTodo` function has been implemented in both `TodoRepositoryDev` (for local/development) and `TodoRepositoryRemote`. The remote repository implementation has been adapted to use the `freezed` generated `TodoApiModel` and a new `UpdateTodoApiModel` (if applicable) for network requests (`refactor: implement updateTodo in TodoRepositoryDev and TodoRepositoryRemote...`).
*   **API Client Adjustments:**
    *   The `updateTodo` method in the `ApiClient` has been refactored to correctly handle the status code from the backend response, ensuring more robust error handling or success confirmation (`refactor: fix statusCode from response in updateTodo from ApiClient`).

**How to Test:**

1.  **Update Todo Item (UI Flow - if applicable):**
    *   If a UI component for editing Todos has been implemented or adapted as part of these changes (e.g., in a `TodoListItem` or a dedicated edit screen):
        *   Navigate to a list of Todos.
        *   Select a Todo item to edit.
        *   Modify its description and/or toggle its `done` status.
        *   Save the changes.
        *   **Verify:** The UI updates to reflect the new Todo item state.
        *   **Verify:** On app restart or data refresh, the changes persist.
2.  **Backend Verification (if using `TodoRepositoryRemote`):**
    *   Perform an update operation that should interact with the remote backend.
    *   **Verify (Backend/API Logs):** Check your backend logs or database to confirm that the PUT/PATCH request to update the Todo was received and processed successfully with the correct data.
    *   **Verify (API Client):** Observe the network request in your app's network inspector (if possible) to ensure the `UpdateTodoApiModel` (or similar) is correctly structured and sent. Confirm the API response (e.g., status code 200 or 204) is handled as expected by the `ApiClient`.
3.  **Local/Dev Repository Verification (if using `TodoRepositoryDev`):**
    *   If testing with the development repository (in-memory or local storage):
        *   Update a Todo item.
        *   **Verify:** The changes are reflected immediately and persist for the current session or according to the dev repository's behavior.
4.  **Serialization/Deserialization:**
    *   Implicitly tested by successfully fetching and updating Todos, but if you have specific unit tests for `Todo.toJson` / `fromJson`, ensure they pass with the new model structure.

